### PR TITLE
Remove recursive cache line

### DIFF
--- a/msm8937/file_contexts
+++ b/msm8937/file_contexts
@@ -47,8 +47,6 @@
 /dev/block/platform/soc/7824900.sdhci/by-name/recovery              u:object_r:recovery_block_device:s0
 /dev/block/platform/soc/7824900.sdhci/by-name/cache                 u:object_r:cache_block_device:s0
 /dev/block/platform/soc/7824900.sdhci/by-name/logdump               u:object_r:logdump_partition:s0
-/dev/block/platform/soc/7824900.sdhci/by-name/cache                 u:object_r:cache_block_device:s0
-
 
 
 #rawdump partition


### PR DESCRIPTION
There is a duplicate line that causes build errors while compiling for the board msm8937